### PR TITLE
fix: type error when checking secret length

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,6 @@ export const cookie = (options: CookieOptions = {}) => {
         ? secretKey
         : secretKey[0]
 
-    const isStringKey = typeof secret === 'string'
-
     return new Elysia({
         name: '@elysiajs/cookie',
         seed: options
@@ -45,11 +43,11 @@ export const cookie = (options: CookieOptions = {}) => {
             if (!secret)
                 throw new Error('No secret is provided to cookie plugin')
 
-            let unsigned: false | string = isStringKey
+            let unsigned: false | string = typeof secret === 'string'
                 ? unsign(value, secret)
                 : false
 
-            if (isStringKey === false)
+            if (typeof secret === 'string')
                 for (let i = 0; i < secret.length; i++) {
                     const temp = unsign(value, secret[i])
 


### PR DESCRIPTION
This fixes the `Property 'length' does not exist on type 'never'.ts(2339)`. Seems like TS don't understand it is a `string`  at this point when branching on `isStringKey`